### PR TITLE
shutdown if miner client fails to connect

### DIFF
--- a/comm.go
+++ b/comm.go
@@ -99,9 +99,10 @@ func (com *Communication) Start(actors []*Actor, client *rpc.Client, btcd *exec.
 	// Start mining.
 	miner, err := NewMiner(addressTable, com.stop, com.start, com.txpool, int32(currentBlock))
 	if err != nil {
-		com.Shutdown(miner, actors, btcd)
 		close(com.stop) // make failedActors goroutine exit
 		close(tpsChan)
+		com.wg.Add(1)
+		go com.Shutdown(miner, actors, btcd)
 		return
 	}
 


### PR DESCRIPTION
Right now, there's a hang which can be reproduced by hardcoding `1` in place of `*maxConnRetries` while trying to connect to the miner:

https://github.com/conformal/btcsim/blob/master/miner.go#L110

We should cleanup and shutdown instead.
