### PR TITLE
interrupt corner case - panic: runtime error:  close of closed channel

### DIFF
--- a/sim.go
+++ b/sim.go
@@ -192,6 +192,12 @@ func main() {
 
 	// close actors and exit btcd on interrupt
 	addInterruptHandler(func() {
+		// ignore if already interrupted before
+		select {
+		case <-com.interrupt:
+			return
+		default:
+		}
 		close(com.interrupt)
 		Close(actors)
 		if err := Exit(btcd); err != nil {


### PR DESCRIPTION
This happens when an interrupt is taking time and a second interrupt is triggered:

```
^C^C2014/08/13 19:26:55 Actor on localhost:18557 shutdown successfully
2014/08/13 19:26:55 Received SIGINT (Ctrl+C).  Shutting down...
2014/08/13 19:26:55 Miner already shutdown
panic: runtime error: close of closed channel

goroutine 27 [running]:
runtime.panic(0x83b22e0, 0x85fe355)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xe9
main.func·011()
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/sim.go:195 +0x41
main.mainInterruptHandler()
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/signal.go:47 +0xbf
created by main.addInterruptHandler
        /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/signal.go:64 +0xb6
```
