### PR TITLE
Fix interrupt hang due to reconnect

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -114,11 +114,12 @@ func (a *Actor) Start(stderr, stdout io.Writer, com *Communication) error {
 
 	// Create and start RPC client.
 	rpcConf := rpc.ConnConfig{
-		Host:         "localhost:" + a.args.port,
-		Endpoint:     "ws",
-		User:         a.args.chainSvr.user,
-		Pass:         a.args.chainSvr.pass,
-		Certificates: a.args.chainSvr.cert,
+		Host:                 "localhost:" + a.args.port,
+		Endpoint:             "ws",
+		User:                 a.args.chainSvr.user,
+		Pass:                 a.args.chainSvr.pass,
+		Certificates:         a.args.chainSvr.cert,
+		DisableAutoReconnect: true,
 	}
 
 	ntfnHandlers := rpc.NotificationHandlers{
@@ -333,7 +334,7 @@ func (a *Actor) WaitForShutdown() {
 // Shutdown kills the actor btcwallet process and removes its data directories.
 func (a *Actor) Shutdown() {
 	if !a.closed {
-		log.Printf("Actor on %s shutdown successfully", "localhost:"+a.args.port)
+		a.client.Shutdown()
 		if err := Exit(a.cmd); err != nil {
 			log.Printf("Cannot exit actor on %s: %v", "localhost:"+a.args.port, err)
 		}
@@ -341,6 +342,7 @@ func (a *Actor) Shutdown() {
 			log.Printf("Cannot cleanup actor directory on %s: %v", "localhost:"+a.args.port, err)
 		}
 		a.closed = true
+		log.Printf("Actor on %s shutdown successfully", "localhost:"+a.args.port)
 	} else {
 		log.Printf("Actor on %s already shutdown", "localhost:"+a.args.port)
 	}

--- a/miner.go
+++ b/miner.go
@@ -70,11 +70,12 @@ func NewMiner(addressTable []btcutil.Address, stop chan<- struct{},
 
 	// RPC mining client initialization.
 	rpcConf := rpc.ConnConfig{
-		Host:         "localhost:18551",
-		Endpoint:     "ws",
-		User:         defaultChainServer.user,
-		Pass:         defaultChainServer.pass,
-		Certificates: defaultChainServer.cert,
+		Host:                 "localhost:18551",
+		Endpoint:             "ws",
+		User:                 defaultChainServer.user,
+		Pass:                 defaultChainServer.pass,
+		Certificates:         defaultChainServer.cert,
+		DisableAutoReconnect: true,
 	}
 
 	ntfnHandlers := rpc.NotificationHandlers{
@@ -144,6 +145,7 @@ func NewMiner(addressTable []btcutil.Address, stop chan<- struct{},
 // log directories.
 func (m *Miner) Shutdown() {
 	if !m.closed {
+		m.client.Shutdown()
 		if err := Exit(m.cmd); err != nil {
 			log.Printf("Cannot kill mining btcd process: %v", err)
 			return

--- a/sim.go
+++ b/sim.go
@@ -142,11 +142,12 @@ func main() {
 
 	// Create and start RPC client.
 	rpcConf := rpc.ConnConfig{
-		Host:         defaultChainServer.connect,
-		Endpoint:     "ws",
-		User:         defaultChainServer.user,
-		Pass:         defaultChainServer.pass,
-		Certificates: defaultChainServer.cert,
+		Host:                 defaultChainServer.connect,
+		Endpoint:             "ws",
+		User:                 defaultChainServer.user,
+		Pass:                 defaultChainServer.pass,
+		Certificates:         defaultChainServer.cert,
+		DisableAutoReconnect: true,
 	}
 
 	ntfnHandlers := rpc.NotificationHandlers{


### PR DESCRIPTION
Sometimes the underlying `btcd` instance was shutdown before the client finished a request and it was causing the client to try and reconnect and therefore hang. Fixed by setting `DisableAutoReconnect` to `true` and calling `Disconnect` to make sure no more requests are made after `Shutdown`.
