### PR TITLE
interrupt corner case - panic

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -321,7 +321,6 @@ func (a *Actor) Stop() {
 	case <-a.quit:
 	default:
 		go a.drainChans()
-		a.client.Shutdown()
 		close(a.quit)
 	}
 }
@@ -334,12 +333,16 @@ func (a *Actor) WaitForShutdown() {
 // Shutdown kills the actor btcwallet process and removes its data directories.
 func (a *Actor) Shutdown() {
 	if !a.closed {
-		a.client.Shutdown()
-		if err := Exit(a.cmd); err != nil {
-			log.Printf("Cannot exit actor on %s: %v", "localhost:"+a.args.port, err)
+		if a.client != nil {
+			a.client.Shutdown()
 		}
-		if err := a.Cleanup(); err != nil {
-			log.Printf("Cannot cleanup actor directory on %s: %v", "localhost:"+a.args.port, err)
+		if a.cmd != nil {
+			if err := Exit(a.cmd); err != nil {
+				log.Printf("Cannot exit actor on %s: %v", "localhost:"+a.args.port, err)
+			}
+			if err := a.Cleanup(); err != nil {
+				log.Printf("Cannot cleanup actor directory on %s: %v", "localhost:"+a.args.port, err)
+			}
 		}
 		a.closed = true
 		log.Printf("Actor on %s shutdown successfully", "localhost:"+a.args.port)


### PR DESCRIPTION
when btcsim is interrupted just after it starts up, there's a chance of hitting this:

    2014/08/18 21:28:57 Received SIGINT (Ctrl+C).  Shutting down...
    21:28:57 2014-08-18 [INF] BTCW: Received SIGINT (Ctrl+C).  Shutting down...
    21:28:57 2014-08-18 [WRN] BTCW: Server shutting down
    21:28:57 2014-08-18 [INF] BTCW: Shutdown complete
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xb code=0x1 addr=0x1 pc=0x80df4f7]

    goroutine 28 [running]:
    runtime.panic(0x83b2bc0, 0x85ff4b3)
            /usr/local/go/src/pkg/runtime/panic.c:279 +0xe9
    github.com/conformal/btcrpcclient.(*Client).Shutdown(0x0)
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcrpcclient/infrastructure.go:938 +0x1a7
    main.(*Actor).Stop(0x189a2360)
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/actor.go:341 +0x73
    main.Close(0x1885a540, 0x1, 0x1)
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/sim.go:275 +0x60
    main.func·015()
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/sim.go:239 +0x80
    main.mainInterruptHandler()
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/signal.go:47 +0xbf
    created by main.addInterruptHandler
            /home/tuxcanfly/Work/conformal/src/github.com/conformal/btcsim/signal.go:64 +0xb6
