### PR TITLE
simplify exit and cleanup

### DIFF
--- a/sim.go
+++ b/sim.go
@@ -206,14 +206,9 @@ func main() {
 		actors = append(actors, a)
 	}
 
-	// close actors and exit btcd on interrupt
+	// if we receive an interrupt, proceed to shutdown
 	addInterruptHandler(func() {
 		safeClose(com.exit)
-		Close(actors)
-		if err := Exit(btcd); err != nil {
-			log.Printf("Cannot kill initial btcd process: %v", err)
-		}
-		safeClose(com.waitForExit)
 	})
 
 	// Start simulation.


### PR DESCRIPTION
We had two channels `exit` and `waitForExit`, but both were being used for the same purpose. Also, cleanup is already being done in `Shutdown` goroutine so removed it from interrupt handlers. This was causing panics due to double close of `a.quit` chan.
