### PR TITLE
Added travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+go:
+  - 1.2
+  - release
+  - tip
+install:
+  - go get -d -t -v ./...
+  - go get -v code.google.com/p/go.tools/cmd/vet
+  - go get -v github.com/GeertJohan/fgt
+  - go get -v github.com/golang/lint/golint
+script:
+  - export PATH=$PATH:$HOME/gopath/bin
+  - go vet
+  - fgt golint


### PR DESCRIPTION
Covers `go vet` and `go lint`, no tests at the moment.
