### PR TITLE
tx err: no outputs

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -233,6 +233,7 @@ func (a *Actor) simulateTx(downstream <-chan btcutil.Address, txpool chan<- stru
 				}}
 
 				// Provide a fees of minFee to ensure the tx gets mined
+				// the utxo amount is guaranteed to be > maxSplit*minFee
 				amt := utxo.Amount - minFee
 				amounts := map[btcutil.Address]btcutil.Amount{
 					addr: amt,
@@ -279,6 +280,7 @@ func (a *Actor) splitUtxos(split <-chan int, txpool chan<- struct{}) {
 				}}
 
 				// Provide a fees of minFee to ensure the tx gets mined
+				// the utxo amount is guaranteed to be > maxSplit*minFee
 				amt := utxo.Amount - minFee
 				amounts := map[btcutil.Address]btcutil.Amount{}
 

--- a/sim.go
+++ b/sim.go
@@ -60,6 +60,9 @@ var (
 	// maxBlockSize defines the maximum block size to be passed as -blockmaxsize to the miner
 	maxBlockSize = flag.Int("maxblocksize", 999000, "Maximum block size used by the miner")
 
+	// maxSplit defines the maximum number of pieces to divide a utxo into
+	maxSplit = flag.Int("maxsplit", 100, "Maximum number of pieces to divide a utxo into")
+
 	// txCurvePath is the path to a CSV file containing the block, utxo count, tx count
 	txCurvePath = flag.String("txcurve", "",
 		"Path to the CSV File containing block, utxo count, tx count fields")
@@ -114,6 +117,12 @@ func main() {
 		if block < *matureBlock {
 			*matureBlock = block
 		}
+	}
+
+	if *maxSplit > *maxAddresses {
+		// cap max split at maxaddresses, becauase each split requires
+		// a unique return address
+		*maxSplit = *maxAddresses
 	}
 
 	actors := make([]*Actor, 0, *maxActors)


### PR DESCRIPTION
Added a check to prevent dust from entering the actor utxo queue.

Prevent the `amounts` map from being empty and resulting in "transaction error: no outputs"

This also fixes #52 which could be happening due to `utxo.Amount` being equal to `minFee` and hence output amount being 0.
