### PR TITLE
renamed to export BtcdArgs, BtcwalletArgs

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -60,7 +60,7 @@ func NewActor(node *Node, port uint16) (*Actor, error) {
 	}
 
 	// Set btcwallet node args
-	args, err := NewBtcwalletArgs(port, node.Args.(*btcdArgs))
+	args, err := NewBtcwalletArgs(port, node.Args.(*BtcdArgs))
 	if err != nil {
 		return nil, err
 	}

--- a/btcd.go
+++ b/btcd.go
@@ -14,9 +14,9 @@ import (
 	"github.com/conformal/btcwire"
 )
 
-// btcdArgs contains all the args and data required to launch a btcd
+// BtcdArgs contains all the args and data required to launch a btcd
 // instance and connect the rpc client to it
-type btcdArgs struct {
+type BtcdArgs struct {
 	RPCUser    string
 	RPCPass    string
 	Listen     string
@@ -36,9 +36,9 @@ type btcdArgs struct {
 	certificates []byte
 }
 
-// NewBtcdArgs returns a btcdArgs with all default values
-func NewBtcdArgs(prefix string) (*btcdArgs, error) {
-	a := &btcdArgs{
+// NewBtcdArgs returns a BtcdArgs with all default values
+func NewBtcdArgs(prefix string) (*BtcdArgs, error) {
+	a := &BtcdArgs{
 		Listen:    "127.0.0.1:18555",
 		RPCListen: "127.0.0.1:18556",
 		RPCUser:   "user",
@@ -57,7 +57,7 @@ func NewBtcdArgs(prefix string) (*btcdArgs, error) {
 // SetDefaults sets the default values of args
 // it creates tmp data and log directories and must
 // be cleaned up by calling Cleanup
-func (a *btcdArgs) SetDefaults() error {
+func (a *BtcdArgs) SetDefaults() error {
 	datadir, err := ioutil.TempDir("", a.prefix+"-data")
 	if err != nil {
 		return err
@@ -80,13 +80,13 @@ func (a *btcdArgs) SetDefaults() error {
 }
 
 // String returns a printable name of this instance
-func (a *btcdArgs) String() string {
+func (a *BtcdArgs) String() string {
 	return a.prefix
 }
 
 // Arguments returns an array of arguments that be used to launch the
 // btcd instance
-func (a *btcdArgs) Arguments() []string {
+func (a *BtcdArgs) Arguments() []string {
 	args := []string{}
 	// --simnet
 	args = append(args, fmt.Sprintf("--%s", strings.ToLower(btcwire.SimNet.String())))
@@ -139,13 +139,13 @@ func (a *btcdArgs) Arguments() []string {
 }
 
 // Command returns Cmd of the btcd instance
-func (a *btcdArgs) Command() *exec.Cmd {
+func (a *BtcdArgs) Command() *exec.Cmd {
 	return exec.Command(a.exe, a.Arguments()...)
 }
 
 // RPCConnConfig returns the rpc connection config that can be used
 // to connect to the btcd instance that is launched on Start
-func (a *btcdArgs) RPCConnConfig() rpc.ConnConfig {
+func (a *BtcdArgs) RPCConnConfig() rpc.ConnConfig {
 	return rpc.ConnConfig{
 		Host:                 a.RPCListen,
 		Endpoint:             a.endpoint,
@@ -157,7 +157,7 @@ func (a *btcdArgs) RPCConnConfig() rpc.ConnConfig {
 }
 
 // Cleanup removes the tmp data and log directories
-func (a *btcdArgs) Cleanup() error {
+func (a *BtcdArgs) Cleanup() error {
 	dirs := []string{
 		a.LogDir,
 		a.DataDir,

--- a/btcd_test.go
+++ b/btcd_test.go
@@ -9,7 +9,7 @@ func TestNewBtcdArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("NewBtcdArgs error: %v", err)
 	}
-	expectedArgs := &btcdArgs{
+	expectedArgs := &BtcdArgs{
 		// fixed
 		Listen:    "127.0.0.1:18555",
 		RPCListen: "127.0.0.1:18556",

--- a/btcwallet.go
+++ b/btcwallet.go
@@ -12,9 +12,9 @@ import (
 	"github.com/conformal/btcwire"
 )
 
-// btcwalletArgs contains all the args and data required to launch a btcwallet
+// BtcwalletArgs contains all the args and data required to launch a btcwallet
 // instance and connect the rpc client to it
-type btcwalletArgs struct {
+type BtcwalletArgs struct {
 	Username   string
 	Password   string
 	RPCListen  string
@@ -34,9 +34,9 @@ type btcwalletArgs struct {
 	endpoint string
 }
 
-// NewBtcwalletArgs returns a btcwalletArgs with all default values
-func NewBtcwalletArgs(port uint16, nodeArgs *btcdArgs) (*btcwalletArgs, error) {
-	a := &btcwalletArgs{
+// NewBtcwalletArgs returns a BtcwalletArgs with all default values
+func NewBtcwalletArgs(port uint16, nodeArgs *BtcdArgs) (*BtcwalletArgs, error) {
+	a := &BtcwalletArgs{
 		RPCListen:    fmt.Sprintf("127.0.0.1:%d", port),
 		RPCConnect:   "127.0.0.1:18556",
 		Username:     "user",
@@ -58,7 +58,7 @@ func NewBtcwalletArgs(port uint16, nodeArgs *btcdArgs) (*btcwalletArgs, error) {
 // SetDefaults sets the default values of args
 // it creates tmp data and log directories and must
 // be cleaned up by calling Cleanup
-func (a *btcwalletArgs) SetDefaults() error {
+func (a *BtcwalletArgs) SetDefaults() error {
 	datadir, err := ioutil.TempDir("", a.prefix+"-data")
 	if err != nil {
 		return err
@@ -73,13 +73,13 @@ func (a *btcwalletArgs) SetDefaults() error {
 }
 
 // String returns a printable name of this instance
-func (a *btcwalletArgs) String() string {
+func (a *BtcwalletArgs) String() string {
 	return a.prefix
 }
 
 // Arguments returns an array of arguments that be used to launch the
 // btcwallet instance
-func (a *btcwalletArgs) Arguments() []string {
+func (a *BtcwalletArgs) Arguments() []string {
 	args := []string{}
 	// --simnet
 	args = append(args, fmt.Sprintf("--%s", strings.ToLower(btcwire.SimNet.String())))
@@ -128,13 +128,13 @@ func (a *btcwalletArgs) Arguments() []string {
 }
 
 // Command returns Cmd of the btcwallet instance
-func (a *btcwalletArgs) Command() *exec.Cmd {
+func (a *BtcwalletArgs) Command() *exec.Cmd {
 	return exec.Command(a.exe, a.Arguments()...)
 }
 
 // RPCConnConfig returns the rpc connection config that can be used
 // to connect to the btcwallet instance that is launched on Start
-func (a *btcwalletArgs) RPCConnConfig() rpc.ConnConfig {
+func (a *BtcwalletArgs) RPCConnConfig() rpc.ConnConfig {
 	return rpc.ConnConfig{
 		Host:                 a.RPCListen,
 		Endpoint:             a.endpoint,
@@ -146,7 +146,7 @@ func (a *btcwalletArgs) RPCConnConfig() rpc.ConnConfig {
 }
 
 // Cleanup removes the tmp data and log directories
-func (a *btcwalletArgs) Cleanup() error {
+func (a *BtcwalletArgs) Cleanup() error {
 	dirs := []string{
 		a.LogDir,
 		a.DataDir,

--- a/btcwallet_test.go
+++ b/btcwallet_test.go
@@ -3,14 +3,14 @@ package main
 import "testing"
 
 func TestNewBtcwalletArgs(t *testing.T) {
-	btcdArgs, err := NewBtcdArgs("node")
-	args, err := NewBtcwalletArgs(18554, btcdArgs)
-	defer btcdArgs.Cleanup()
+	BtcdArgs, err := NewBtcdArgs("node")
+	args, err := NewBtcwalletArgs(18554, BtcdArgs)
+	defer BtcdArgs.Cleanup()
 	defer args.Cleanup()
 	if err != nil {
 		t.Errorf("NewBtcwalletArgs error: %v", err)
 	}
-	expectedArgs := &btcwalletArgs{
+	expectedArgs := &BtcwalletArgs{
 		// fixed
 		RPCListen:  "127.0.0.1:18554",
 		RPCConnect: "127.0.0.1:18556",

--- a/common.go
+++ b/common.go
@@ -29,8 +29,8 @@ type Args interface {
 
 // Node is a RPC server node, typically btcd or btcwallet and functions to
 // manage the instance
-// All functions common to btcd and btcwallet go here while btcdArgs and
-// btcwalletArgs hold the different implementations
+// All functions common to btcd and btcwallet go here while BtcdArgs and
+// BtcwalletArgs hold the different implementations
 type Node struct {
 	Args
 	handlers *rpc.NotificationHandlers


### PR DESCRIPTION
fixes golint error: 

```
btcd.go:38:34: exported func NewBtcdArgs returns unexported type *main.btcdArgs, which can be annoying to use
btcwallet.go:39:57: exported func NewBtcwalletArgs returns unexported type *main.btcwalletArgs, which can be annoying to use
```
