### PR TITLE
minor improvements in terminology, csv input

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ involved. btcsim uses `btcrpcclient` to interface with the RPC servers.
 
 The input is read from a CSV file with the following headers:
 
-    | block number | minimum utxos required | transactions required |
+    | block height | minimum utxos required | transactions required |
 
 Example:
 

--- a/main.go
+++ b/main.go
@@ -27,13 +27,13 @@ var (
 	// numActors defines the number of actors to spawn
 	numActors = flag.Int("actors", 1, "Number of actors to be launched")
 
-	// maxBlocks defines how many blocks have to connect to the blockchain
+	// stopBlock defines how many blocks have to connect to the blockchain
 	// before the simulation normally stops
-	maxBlocks = flag.Int("maxblocks", 20000, "Maximum blocks to generate")
+	stopBlock = flag.Int("stopblock", 15000, "Block height to stop the simulation at")
 
-	// matureBlock defines after which block the blockchain is mature enough to start
+	// startBlock defines after which block the blockchain is start enough to start
 	// controlled mining as per the tx curve
-	matureBlock = flag.Int("matureblock", 20000, "Block number at blockchain maturity")
+	startBlock = flag.Int("startblock", 15000, "Block height to start the simulation at")
 
 	// maxAddresses defines the number of addresses to generate per actor
 	maxAddresses = flag.Int("maxaddresses", 100, "Maximum addresses per actor")

--- a/miner.go
+++ b/miner.go
@@ -25,19 +25,16 @@ func NewMiner(miningAddrs []btcutil.Address, exit chan struct{},
 	height chan<- int32, txpool chan<- struct{}) (*Miner, error) {
 
 	ntfnHandlers := &rpc.NotificationHandlers{
-		// When a block higher than maxBlocks connects to the chain,
+		// When a block higher than stopBlock connects to the chain,
 		// send a signal to stop actors. This is used so main can break from
 		// select and call actor.Stop to stop actors.
 		OnBlockConnected: func(hash *btcwire.ShaHash, h int32) {
-			if h > int32(*maxBlocks) {
-				close(exit)
-			}
-			if h >= int32(*matureBlock)-1 {
+			if h >= int32(*startBlock)-1 {
 				if height != nil {
 					height <- h
 				}
 			} else {
-				fmt.Printf("\r%d/%d", h, *matureBlock)
+				fmt.Printf("\r%d/%d", h, *startBlock)
 			}
 		},
 		// Send a signal that a tx has been accepted into the mempool. Based on
@@ -109,7 +106,7 @@ func NewMiner(miningAddrs []btcutil.Address, exit chan struct{},
 		return miner, err
 	}
 
-	log.Printf("%s: Generating %v blocks...", miner, *matureBlock)
+	log.Printf("%s: Generating %v blocks...", miner, *startBlock)
 	return miner, nil
 }
 

--- a/simulation.go
+++ b/simulation.go
@@ -56,7 +56,7 @@ func (s *Simulation) readTxCurve(txCurvePath string) error {
 		// linear simulation curve as the default
 		txCurve = make(map[int32]*Row, SimRows)
 		for i := 1; i <= SimRows; i++ {
-			block := int32(*matureBlock + i)
+			block := int32(*startBlock + i)
 			txCurve[block] = &Row{
 				utxoCount: i * SimUtxoCount,
 				txCount:   i * SimTxCount,
@@ -79,11 +79,15 @@ func (s *Simulation) readTxCurve(txCurvePath string) error {
 
 // updateFlags updates the flags based on the txCurve
 func (s *Simulation) updateFlags() {
-	// set min block number from the curve as matureBlock
+	// set min block height from the curve as startBlock
+	// and max block height as stopBlock
 	for k := range s.txCurve {
 		block := int(k)
-		if block < *matureBlock {
-			*matureBlock = block
+		if block < *startBlock {
+			*startBlock = block
+		}
+		if block > *stopBlock {
+			*stopBlock = block
 		}
 	}
 
@@ -92,9 +96,6 @@ func (s *Simulation) updateFlags() {
 		// a unique return address
 		*maxSplit = *maxAddresses
 	}
-	// we need only enough blocks after matureBlock
-	// to generate the tx curve
-	*maxBlocks = *matureBlock + len(s.txCurve) + 1
 }
 
 // Start runs the simulation by launching a node, actors and com.Start


### PR DESCRIPTION
- renamed a few vars that might be confusing, e.g`matureBlock` -> `startBlock`
- fixed a off-by-one in the csv input - matched the block height and no of transactions
- updated starting block to 15000 as the difficulty at that height seems stable enough to control mining
