### PR TITLE
Updated btcutil path

### DIFF
--- a/actor.go
+++ b/actor.go
@@ -13,9 +13,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/conformal/btcjson"
 	rpc "github.com/conformal/btcrpcclient"
-	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
 )
 

--- a/comm.go
+++ b/comm.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcutil"
 	"github.com/conformal/btcchain"
 	"github.com/conformal/btcnet"
 	rpc "github.com/conformal/btcrpcclient"
 	"github.com/conformal/btcscript"
-	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
 )
 

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/conformal/btcutil"
+	"github.com/btcsuite/btcutil"
 
 	"math/rand"
 	_ "net/http/pprof"

--- a/miner.go
+++ b/miner.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/btcsuite/btcutil"
 	rpc "github.com/conformal/btcrpcclient"
-	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
 )
 

--- a/simulation.go
+++ b/simulation.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/btcsuite/btcutil"
 	rpc "github.com/conformal/btcrpcclient"
-	"github.com/conformal/btcutil"
 	"github.com/conformal/btcwire"
 )
 

--- a/utils.go
+++ b/utils.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/conformal/btcutil"
+	"github.com/btcsuite/btcutil"
 )
 
 // Row represents a row in the CSV file


### PR DESCRIPTION
Moving from `github.com/conformal/btcutil` to `github.com/btcsuite/btcutil`